### PR TITLE
pull in all changes from CIR

### DIFF
--- a/Robot/src/main/java/frc/robot/Constants.java
+++ b/Robot/src/main/java/frc/robot/Constants.java
@@ -60,6 +60,7 @@ public final class Constants {
     public static final double ROBOT_LENGTH_WITH_BUMPERS = 0.91;
 
     public static final int PIGEON_ID = 18;
+    public static final int TIMEOUT_MS = 30;
 
     /* Limelight */
     public static  double LIMELIGHT_P = 0.055; // FIXME: adjust when tuning and then make final

--- a/Robot/src/main/java/frc/robot/Constants.java
+++ b/Robot/src/main/java/frc/robot/Constants.java
@@ -72,7 +72,7 @@ public final class Constants {
     public static final int COLLECTOR_MOTOR_ID = 5;
     public static final int PEUNAMATICS_HUB_CAN_ID = 20;
     public static final int COLLECTOR_SOLENOID_CHANNEL = 0;
-    public static final double COLLECTOR_DEFUALT_SPEED = 0.7; // FIX_ME change this to desired speed
+    public static final double COLLECTOR_DEFUALT_SPEED = 0.9; // FIX_ME change this to desired speed; was 0.7
     public static final int TIMEOUT_MS = 30;
 
   }
@@ -111,7 +111,7 @@ public final class Constants {
     public static final int WALL_SHOT_VELOCITY = 7782; // FIXME tune this
     public static final int FENDER_SHOT_VELOCITY = 7799; // FIXME tune this
     public static final int LAUNCH_PAD_VELOCITY = 8447; // FIXME tune this
-    public static final int SHOOT_SLOW_VELOCITY = 2000; // FIXME tune this
+    public static final int SHOOT_SLOW_VELOCITY = 4000; // FIXME tune this
     public static final int SHOT_VELOCITY_DIP = 500;  // FIXME: tune this
     public static final double REVERSE_POWER = -0.2; // FIXME: tune this
 
@@ -167,7 +167,7 @@ public final class Constants {
     public static final int SHOOTER_SENSOR = 1;
     public static final int COLLECTOR_SENSOR = 0;
     public static final int STORAGE_MOTOR_ID = 4;
-    public static final double STORAGE_DEFAULT_SPEED = 0.7;
+    public static final double STORAGE_DEFAULT_SPEED = 0.6;
     public static final int STORAGE_CAMERA_PORT = 0;
     public static final int TIMEOUT_MS = 30;
   }

--- a/Robot/src/main/java/frc/robot/Constants.java
+++ b/Robot/src/main/java/frc/robot/Constants.java
@@ -167,7 +167,7 @@ public final class Constants {
     public static final int SHOOTER_SENSOR = 1;
     public static final int COLLECTOR_SENSOR = 0;
     public static final int STORAGE_MOTOR_ID = 4;
-    public static final double STORAGE_DEFAULT_SPEED = 0.6;
+    public static final double STORAGE_DEFAULT_SPEED = 0.7;
     public static final int STORAGE_CAMERA_PORT = 0;
     public static final int TIMEOUT_MS = 30;
   }

--- a/Robot/src/main/java/frc/robot/Constants.java
+++ b/Robot/src/main/java/frc/robot/Constants.java
@@ -73,6 +73,7 @@ public final class Constants {
     public static final int PEUNAMATICS_HUB_CAN_ID = 20;
     public static final int COLLECTOR_SOLENOID_CHANNEL = 0;
     public static final double COLLECTOR_DEFUALT_SPEED = 0.7; // FIX_ME change this to desired speed
+    public static final int TIMEOUT_MS = 30;
 
   }
 
@@ -168,6 +169,7 @@ public final class Constants {
     public static final int STORAGE_MOTOR_ID = 4;
     public static final double STORAGE_DEFAULT_SPEED = 0.6;
     public static final int STORAGE_CAMERA_PORT = 0;
+    public static final int TIMEOUT_MS = 30;
   }
 
   public static class ElevatorConstants {

--- a/Robot/src/main/java/frc/robot/Robot.java
+++ b/Robot/src/main/java/frc/robot/Robot.java
@@ -126,6 +126,8 @@ public class Robot extends TimedRobot {
             m_autonomousCommand.cancel();
         }
 
+        server.setSource(storageCam);
+
     }
 
     /**
@@ -134,12 +136,12 @@ public class Robot extends TimedRobot {
     @Override
     public void teleopPeriodic() {
 
-        if(this.m_robotContainer.isElevatorControlEnabled()){
-            server.setSource(climbCam);
-        }
-        else{
-            server.setSource(storageCam);
-        }
+        // if(this.m_robotContainer.isElevatorControlEnabled()){
+        //     server.setSource(climbCam);
+        // }
+        // else{
+        //     server.setSource(storageCam);
+        // }
 
     }
     @Override

--- a/Robot/src/main/java/frc/robot/RobotContainer.java
+++ b/Robot/src/main/java/frc/robot/RobotContainer.java
@@ -9,6 +9,7 @@ import com.pathplanner.lib.PathPlannerTrajectory;
 import edu.wpi.first.math.controller.ProfiledPIDController;
 import edu.wpi.first.wpilibj.GenericHID;
 import edu.wpi.first.wpilibj.Joystick;
+import edu.wpi.first.wpilibj.livewindow.LiveWindow;
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.shuffleboard.EventImportance;
 import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
@@ -63,8 +64,8 @@ public class RobotContainer {
   private final Storage m_storage = new Storage();
   private final Collector m_collector = new Collector();
   private final Flywheel m_flywheel = new Flywheel();
-  private final Hood m_hood = new Hood();
-  private final LimelightMath m_limelight = new LimelightMath();
+  //private final Hood m_hood = new Hood();
+  //private final LimelightMath m_limelight = new LimelightMath();
   private final SecondaryArm m_secondMechanism = new SecondaryArm();
   private final Elevator m_elevator = new Elevator();
 
@@ -85,6 +86,8 @@ public class RobotContainer {
    */
   private RobotContainer() {
 
+    LiveWindow.disableAllTelemetry();
+
     this.joystickButtons0 = new JoystickButton[13];
     this.joystickButtons1 = new JoystickButton[13];
     this.operatorButtons = new JoystickButton[13];
@@ -103,8 +106,8 @@ public class RobotContainer {
     m_storage.register();
     m_collector.register();
     m_flywheel.register();
-    m_hood.register();
-    m_limelight.register();
+    //m_hood.register();
+    //m_limelight.register();
     m_storage.register();
     m_elevator.register();
      m_secondMechanism.register();

--- a/Robot/src/main/java/frc/robot/RobotContainer.java
+++ b/Robot/src/main/java/frc/robot/RobotContainer.java
@@ -384,8 +384,6 @@ public class RobotContainer {
     PathPlannerTrajectory autoBlueForwardPath = PathPlanner.loadPath("BlueForward",
         AutoConstants.kMaxSpeedMetersPerSecond, AutoConstants.kMaxAccelerationMetersPerSecondSquared);
     autoBlueForward = new SequentialCommandGroup(
-      new InstantCommand(() -> m_drivetrainSubsystem.setGyroFromPath(autoBlueForwardPath.getInitialState())),
-      new WaitCommand(2.0),
       new FollowPath(autoBlueForwardPath, thetaController, m_drivetrainSubsystem),
       createShootCommandSequence(FlywheelConstants.WALL_SHOT_VELOCITY),
       new WaitForTeleopCommand(m_drivetrainSubsystem, m_flywheel, m_storage, m_collector));
@@ -394,9 +392,8 @@ public class RobotContainer {
           AutoConstants.kMaxSpeedMetersPerSecond, AutoConstants.kMaxAccelerationMetersPerSecondSquared);
       autoBlue1 = new SequentialCommandGroup(
         new InstantCommand(() -> m_collector.enableCollector(), m_collector),
-        new InstantCommand(() -> m_drivetrainSubsystem.setGyroFromPath(autoBlue1Path.getInitialState())),
-        new WaitCommand(2.0),
         new FollowPath(autoBlue1Path, thetaController, m_drivetrainSubsystem),
+        new InstantCommand(() -> m_collector.disableCollector(), m_collector),
         createShootCommandSequence(FlywheelConstants.WALL_SHOT_VELOCITY),
         new WaitForTeleopCommand(m_drivetrainSubsystem, m_flywheel, m_storage, m_collector));
 
@@ -404,17 +401,14 @@ public class RobotContainer {
           AutoConstants.kMaxSpeedMetersPerSecond, AutoConstants.kMaxAccelerationMetersPerSecondSquared);
       autoBlue2 = new SequentialCommandGroup(
         new InstantCommand(() -> m_collector.enableCollector(), m_collector),
-        new InstantCommand(() -> m_drivetrainSubsystem.setGyroFromPath(autoBlue2Path.getInitialState())),
-        new WaitCommand(2.0),
         new FollowPath(autoBlue2Path, thetaController, m_drivetrainSubsystem),
+        new InstantCommand(() -> m_collector.disableCollector(), m_collector),
         createShootCommandSequence(FlywheelConstants.WALL_SHOT_VELOCITY),
         new WaitForTeleopCommand(m_drivetrainSubsystem, m_flywheel, m_storage, m_collector));
 
     PathPlannerTrajectory autoRedForwardPath = PathPlanner.loadPath("RedForward",
           AutoConstants.kMaxSpeedMetersPerSecond, AutoConstants.kMaxAccelerationMetersPerSecondSquared);
     autoRedForward = new SequentialCommandGroup(
-      new InstantCommand(() -> m_drivetrainSubsystem.setGyroFromPath(autoRedForwardPath.getInitialState())),
-      new WaitCommand(2.0),
       new FollowPath(autoRedForwardPath, thetaController, m_drivetrainSubsystem),
       createShootCommandSequence(FlywheelConstants.WALL_SHOT_VELOCITY),
       new WaitForTeleopCommand(m_drivetrainSubsystem, m_flywheel, m_storage, m_collector));
@@ -423,9 +417,8 @@ public class RobotContainer {
           AutoConstants.kMaxSpeedMetersPerSecond, AutoConstants.kMaxAccelerationMetersPerSecondSquared);
     autoRed1 = new SequentialCommandGroup(
       new InstantCommand(() -> m_collector.enableCollector(), m_collector),
-      new InstantCommand(() -> m_drivetrainSubsystem.setGyroFromPath(autoRed1Path.getInitialState())),
-      new WaitCommand(2.0),
       new FollowPath(autoRed1Path, thetaController, m_drivetrainSubsystem),
+      new InstantCommand(() -> m_collector.disableCollector(), m_collector),
       createShootCommandSequence(FlywheelConstants.WALL_SHOT_VELOCITY),
       new WaitForTeleopCommand(m_drivetrainSubsystem, m_flywheel, m_storage, m_collector));
 
@@ -433,9 +426,8 @@ public class RobotContainer {
           AutoConstants.kMaxSpeedMetersPerSecond, AutoConstants.kMaxAccelerationMetersPerSecondSquared);
     autoRed2 = new SequentialCommandGroup(
       new InstantCommand(() -> m_collector.enableCollector(), m_collector),
-      new InstantCommand(() -> m_drivetrainSubsystem.setGyroFromPath(autoRed2Path.getInitialState())),
-      new WaitCommand(2.0),
       new FollowPath(autoRed2Path, thetaController, m_drivetrainSubsystem),
+      new InstantCommand(() -> m_collector.disableCollector(), m_collector),
       createShootCommandSequence(FlywheelConstants.WALL_SHOT_VELOCITY),
       new WaitForTeleopCommand(m_drivetrainSubsystem, m_flywheel, m_storage, m_collector));
 

--- a/Robot/src/main/java/frc/robot/commands/FollowPath.java
+++ b/Robot/src/main/java/frc/robot/commands/FollowPath.java
@@ -31,6 +31,8 @@ public class FollowPath extends PPSwerveControllerCommand {
     public void initialize() {
         super.initialize();
 
+        this.drivetrainSubsystem.setGyroOffset(this.trajectory.getInitialState().holonomicRotation.getDegrees());
+
         // reset the theta controller such that old accumuldated ID values aren't used with the new path
         //      this doesn't matter if only the P value is non-zero, which is the current behavior
         this.thetaController.reset(this.drivetrainSubsystem.getPose().getRotation().getRadians());

--- a/Robot/src/main/java/frc/robot/commands/SetFlywheelVelocityCommand.java
+++ b/Robot/src/main/java/frc/robot/commands/SetFlywheelVelocityCommand.java
@@ -8,15 +8,15 @@ public class SetFlywheelVelocityCommand extends CommandBase {
     private Flywheel flywheel;
     private double velocity;
 
-    public SetFlywheelVelocityCommand(Flywheel flywheel, LimelightMath limelight) {
-        this.flywheel = flywheel;
-        // FIXME: this will get the ideal velocity when the command is constructed; not
-        // when the command is scheduled
-        // The next line should be moved to the initialzie method.
-        this.velocity = limelight.getIdealVelocity();
-        addRequirements(this.flywheel);
+    // public SetFlywheelVelocityCommand(Flywheel flywheel, LimelightMath limelight) {
+    //     this.flywheel = flywheel;
+    //     // FIXME: this will get the ideal velocity when the command is constructed; not
+    //     // when the command is scheduled
+    //     // The next line should be moved to the initialzie method.
+    //     this.velocity = limelight.getIdealVelocity();
+    //     addRequirements(this.flywheel);
 
-    }
+    // }
 
     public SetFlywheelVelocityCommand(Flywheel flywheel, double velocity) {
         this.flywheel = flywheel;

--- a/Robot/src/main/java/frc/robot/commands/SortStorageCommand.java
+++ b/Robot/src/main/java/frc/robot/commands/SortStorageCommand.java
@@ -29,10 +29,10 @@ public class SortStorageCommand extends CommandBase {
     public void execute() {
         if (!this.m_storage.isShooterSensorUnblocked()) {
             indexingDelay++;
-            if(indexingDelay == 6) {
+            if(indexingDelay == 8) {
                 this.m_storage.setStoragePower(StorageConstants.OUTTAKE_POWER);
             }
-            else if(indexingDelay > 6) {
+            else if(indexingDelay > 8) {
                 this.m_storage.disableStorage();
             }
         } else if (!this.m_storage.isCollectorSensorUnblocked() & this.m_storage.isShooterSensorUnblocked()) {

--- a/Robot/src/main/java/frc/robot/commands/SortStorageCommand.java
+++ b/Robot/src/main/java/frc/robot/commands/SortStorageCommand.java
@@ -2,6 +2,7 @@ package frc.robot.commands;
 
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import frc.robot.subsystems.*;
+import static frc.robot.Constants.*;
 
 /**
  * This command continuously runs the belt in the feeder until cargo is detected
@@ -28,7 +29,10 @@ public class SortStorageCommand extends CommandBase {
     public void execute() {
         if (!this.m_storage.isShooterSensorUnblocked()) {
             indexingDelay++;
-            if(indexingDelay > 5) {
+            if(indexingDelay == 6) {
+                this.m_storage.setStoragePower(StorageConstants.OUTTAKE_POWER);
+            }
+            else if(indexingDelay > 6) {
                 this.m_storage.disableStorage();
             }
         } else if (!this.m_storage.isCollectorSensorUnblocked() & this.m_storage.isShooterSensorUnblocked()) {

--- a/Robot/src/main/java/frc/robot/subsystems/Collector.java
+++ b/Robot/src/main/java/frc/robot/subsystems/Collector.java
@@ -1,6 +1,6 @@
 package frc.robot.subsystems;
 
-import static frc.robot.Constants.CollectorConstants.*;
+import frc.robot.Constants.CollectorConstants;
 import static frc.robot.Constants.*;
 
 import edu.wpi.first.wpilibj.shuffleboard.BuiltInWidgets;

--- a/Robot/src/main/java/frc/robot/subsystems/Collector.java
+++ b/Robot/src/main/java/frc/robot/subsystems/Collector.java
@@ -1,6 +1,6 @@
 package frc.robot.subsystems;
 
-import frc.robot.Constants.CollectorConstants;
+import static frc.robot.Constants.CollectorConstants.*;
 import static frc.robot.Constants.*;
 
 import edu.wpi.first.wpilibj.shuffleboard.BuiltInWidgets;
@@ -9,6 +9,7 @@ import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
 import com.ctre.phoenix.motorcontrol.ControlMode;
+import com.ctre.phoenix.motorcontrol.StatusFrameEnhanced;
 import com.ctre.phoenix.motorcontrol.can.WPI_TalonSRX;
 
 import edu.wpi.first.networktables.NetworkTableEntry;
@@ -31,6 +32,9 @@ public class Collector extends SubsystemBase {
         isEnabled = false;
         collector5 = new WPI_TalonSRX(CollectorConstants.COLLECTOR_MOTOR_ID);
         collector5.setInverted(true);
+
+        this.collector5.setStatusFramePeriod(StatusFrameEnhanced.Status_1_General, 255, TIMEOUT_MS);
+        this.collector5.setStatusFramePeriod(StatusFrameEnhanced.Status_2_Feedback0, 255, TIMEOUT_MS);
 
         collectorPiston = new Solenoid(CollectorConstants.PEUNAMATICS_HUB_CAN_ID, PneumaticsModuleType.REVPH,
                 CollectorConstants.COLLECTOR_SOLENOID_CHANNEL);

--- a/Robot/src/main/java/frc/robot/subsystems/DrivetrainSubsystem.java
+++ b/Robot/src/main/java/frc/robot/subsystems/DrivetrainSubsystem.java
@@ -4,6 +4,7 @@
 
 package frc.robot.subsystems;
 
+import com.ctre.phoenix.sensors.PigeonIMU_StatusFrame;
 //import com.ctre.phoenix.sensors.PigeonIMU;
 import com.ctre.phoenix.sensors.Pigeon2;
 import com.pathplanner.lib.PathPlannerTrajectory.PathPlannerState;
@@ -115,6 +116,7 @@ public class DrivetrainSubsystem extends SubsystemBase {
                 // this.m_robotCenter = new Translation2d(0,0);
 
                 m_pigeon.setYaw(0.0);
+                this.m_pigeon.setStatusFramePeriod(PigeonIMU_StatusFrame.CondStatus_6_SensorFusion, 255, TIMEOUT_MS);
 
                 // There are 4 methods you can call to create your swerve modules.
                 // The method you use depends on what motors you are using.

--- a/Robot/src/main/java/frc/robot/subsystems/DrivetrainSubsystem.java
+++ b/Robot/src/main/java/frc/robot/subsystems/DrivetrainSubsystem.java
@@ -107,6 +107,7 @@ public class DrivetrainSubsystem extends SubsystemBase {
         private SimpleMotorFeedforward feedForward;
 
         private int aimSetpointCount;
+        private double lastLimelightDistance;
 
         public DrivetrainSubsystem() {
                 ShuffleboardTab tab = Shuffleboard.getTab("Drivetrain");
@@ -194,10 +195,10 @@ public class DrivetrainSubsystem extends SubsystemBase {
                 this.feedForward = new SimpleMotorFeedforward(AutoConstants.ksVolts,
                                 AutoConstants.kvVoltSecondsPerMeter, AutoConstants.kaVoltSecondsSquaredPerMeter);
 
+                tabMain.addNumber("Limelight Dist", () -> getLimelightDistanceIn());
                 tabMain.addBoolean("Launchpad Dist", () -> isAtLaunchpadDistance());
                 tabMain.addBoolean("Wall Dist", () -> isAtWallDistance());
                 tabMain.addBoolean("Is Aimed", () -> isAimed());
-                tabMain.addNumber("Limelight Dist", () -> getLimelightDistanceIn());
                 tabMain.addNumber("Gyroscope Angle", () -> getGyroscopeRotation().getDegrees());
                 tabMain.addBoolean("isXstance", this :: isXstance);
                 this.fieldRelativeNT = Shuffleboard.getTab("MAIN")
@@ -395,20 +396,18 @@ public class DrivetrainSubsystem extends SubsystemBase {
         public double getLimelightDistanceIn() {
                 double ty = NetworkTableInstance.getDefault().getTable("limelight").getEntry("ty").getDouble(0.0);
 
-                double d = (LimelightConstants.HUB_H - LimelightConstants.ROBOT_H)
+                this.lastLimelightDistance = (LimelightConstants.HUB_H - LimelightConstants.ROBOT_H)
                         / (Math.tan(Math.toRadians(LimelightConstants.LIMELIGHT_MOUNT_ANGLE +LimelightConstants.LIMELIGHT_ANGLE_OFFSET + ty)));
-
-                return d;
+                
+                return this.lastLimelightDistance;
         }
 
         public boolean isAtLaunchpadDistance() {
-                double dist = getLimelightDistanceIn();
-                return Math.abs(LimelightConstants.HUB_LAUNCHPAD_DISTANCE - dist) <= LimelightConstants.DISTANCE_TOLERANCE;
+                return Math.abs(LimelightConstants.HUB_LAUNCHPAD_DISTANCE - this.lastLimelightDistance) <= LimelightConstants.DISTANCE_TOLERANCE;
         }
 
         public boolean isAtWallDistance() {
-                double dist = getLimelightDistanceIn();
-                return Math.abs(LimelightConstants.HUB_WALL_DISTANCE - dist) <= LimelightConstants.DISTANCE_TOLERANCE;
+                return Math.abs(LimelightConstants.HUB_WALL_DISTANCE - this.lastLimelightDistance) <= LimelightConstants.DISTANCE_TOLERANCE;
         }
 
         public void aim(double translationXSupplier, double translationYSupplier, double rotationSupplier) {

--- a/Robot/src/main/java/frc/robot/subsystems/DrivetrainSubsystem.java
+++ b/Robot/src/main/java/frc/robot/subsystems/DrivetrainSubsystem.java
@@ -202,6 +202,7 @@ public class DrivetrainSubsystem extends SubsystemBase {
                 tabMain.addBoolean("Wall Dist", () -> isAtWallDistance());
                 tabMain.addBoolean("Is Aimed", () -> isAimed());
                 tabMain.addNumber("Gyroscope Angle", () -> getGyroscopeRotation().getDegrees());
+                tabMain.addNumber("Gyroscope Offset", () -> this.gyroOffset);
                 tabMain.addBoolean("isXstance", this :: isXstance);
                 this.fieldRelativeNT = Shuffleboard.getTab("MAIN")
                                 .add("FieldRelativeState", this.isFieldRelative)

--- a/Robot/src/main/java/frc/robot/subsystems/Elevator.java
+++ b/Robot/src/main/java/frc/robot/subsystems/Elevator.java
@@ -13,6 +13,7 @@ import com.ctre.phoenix.motorcontrol.TalonFXControlMode;
 import com.ctre.phoenix.motorcontrol.TalonFXFeedbackDevice;
 import com.ctre.phoenix.motorcontrol.TalonFXInvertType;
 import com.ctre.phoenix.motorcontrol.NeutralMode;
+import com.ctre.phoenix.motorcontrol.StatusFrameEnhanced;
 
 import edu.wpi.first.networktables.EntryListenerFlags;
 import edu.wpi.first.networktables.NetworkTableEntry;
@@ -129,6 +130,9 @@ public class Elevator extends SubsystemBase {
 
         /* Initialize */
         this.rightElevatorMotor.getSensorCollection().setIntegratedSensorPosition(0, kTimeoutMs);
+
+		this.leftElevatorMotor.setStatusFramePeriod(StatusFrameEnhanced.Status_1_General, 255, kTimeoutMs);
+        this.leftElevatorMotor.setStatusFramePeriod(StatusFrameEnhanced.Status_2_Feedback0, 255, kTimeoutMs);
 
         Shuffleboard.getTab("MAIN").addBoolean("Elevator At Setpoint", this::atSetpoint);
         

--- a/Robot/src/main/java/frc/robot/subsystems/Flywheel.java
+++ b/Robot/src/main/java/frc/robot/subsystems/Flywheel.java
@@ -13,6 +13,7 @@ import frc.robot.commands.SetFlywheelVelocityCommand;
 import java.util.Map;
 
 import com.ctre.phoenix.motorcontrol.NeutralMode;
+import com.ctre.phoenix.motorcontrol.StatusFrameEnhanced;
 import com.ctre.phoenix.motorcontrol.TalonFXControlMode;
 import com.ctre.phoenix.motorcontrol.TalonFXFeedbackDevice;
 import com.ctre.phoenix.motorcontrol.TalonFXInvertType;
@@ -104,6 +105,9 @@ public class Flywheel extends SubsystemBase {
 
         /* APPLY the config settings */
         this.rightFlywheelMotor.configAllSettings(_rightConfig);
+
+        this.leftFlywheelMotor.setStatusFramePeriod(StatusFrameEnhanced.Status_1_General, 255, TIMEOUT_MS);
+        this.leftFlywheelMotor.setStatusFramePeriod(StatusFrameEnhanced.Status_2_Feedback0, 255, TIMEOUT_MS);
 
         // rightFlywheelMotor.selectProfileSlot(SLOT_INDEX, PID_LOOP_INDEX);
 

--- a/Robot/src/main/java/frc/robot/subsystems/Storage.java
+++ b/Robot/src/main/java/frc/robot/subsystems/Storage.java
@@ -43,10 +43,10 @@ public class Storage extends SubsystemBase {
         shooterSensor1 = new DigitalInput(StorageConstants.SHOOTER_SENSOR);
         addChild("Shooter Sensor 1", shooterSensor1);
 
-        Shuffleboard.getTab("MAIN").addBoolean("Collector Unblocked", this::isCollectorSensorUnblocked);
-        Shuffleboard.getTab("MAIN").addBoolean("Shooter Unblocked", this::isShooterSensorUnblocked);
         
         if(COMMAND_LOGGING) {
+            Shuffleboard.getTab("MAIN").addBoolean("Collector Unblocked", this::isCollectorSensorUnblocked);
+            Shuffleboard.getTab("MAIN").addBoolean("Shooter Unblocked", this::isShooterSensorUnblocked);
             Shuffleboard.getTab("Storage").add("storage", this);
             Shuffleboard.getTab("Storage").add("Sort Storage", new SortStorageCommand(this));
         }

--- a/Robot/src/main/java/frc/robot/subsystems/Storage.java
+++ b/Robot/src/main/java/frc/robot/subsystems/Storage.java
@@ -1,6 +1,7 @@
 package frc.robot.subsystems;
 
 import static frc.robot.Constants.*;
+import static frc.robot.Constants.StorageConstants.*;
 
 import java.util.Map;
 
@@ -10,6 +11,7 @@ import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.commands.SortStorageCommand;
 
 import com.ctre.phoenix.motorcontrol.ControlMode;
+import com.ctre.phoenix.motorcontrol.StatusFrameEnhanced;
 import com.ctre.phoenix.motorcontrol.can.WPI_TalonSRX;
 
 import edu.wpi.first.networktables.EntryListenerFlags;
@@ -31,6 +33,9 @@ public class Storage extends SubsystemBase {
     public Storage() {
         this.isStorageEnabled = false;
         storage4 = new WPI_TalonSRX(StorageConstants.STORAGE_MOTOR_ID);
+
+        this.storage4.setStatusFramePeriod(StatusFrameEnhanced.Status_1_General, 255, TIMEOUT_MS);
+        this.storage4.setStatusFramePeriod(StatusFrameEnhanced.Status_2_Feedback0, 255, TIMEOUT_MS);
 
         collectorSensor0 = new DigitalInput(StorageConstants.COLLECTOR_SENSOR);
         addChild("Collector Sensor 0", collectorSensor0);


### PR DESCRIPTION
- reduce traffic on CAN bus
- increase collector power from 0.7 to 0.9
- increase shoot slow velocity from 2000 to 4000
- support only collector camera
- disable creation of Hood and LimelightMath objects
- disable LiveWindow telemetry
- fix (hopefully) gyro angle based on position on field
- bring in collector during auto at end of path
- tweak indexing algorithm to keep storage running 40ms longer and then reverse for 20ms
- reduce NetworkTable calls to get limelight distance